### PR TITLE
Maybe fix a unicode encoding issue with python2

### DIFF
--- a/openssh_wrapper.py
+++ b/openssh_wrapper.py
@@ -448,9 +448,9 @@ class SSHResult(object):
     def repr_binary(self):
         """ Build simple unicode representation from all member values. """
         ret = []
-        ret += [b('command: '), self.command, b('\n')]
-        ret += [b('stdout: '), self.stdout, b('\n')]
-        ret += [b('stderr: '), self.stderr, b('\n')]
+        ret += [b('command: '), b(self.command), b('\n')]
+        ret += [b('stdout: '), b(self.stdout), b('\n')]
+        ret += [b('stderr: '), b(self.stderr), b('\n')]
         ret += [b('returncode: '), b(text(self.returncode))]
         return b('').join(ret)
 


### PR DESCRIPTION
With this, I no longer get the following error:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3932: ordinal not in range(128)    
    logger.info('SSH execution result: {}'.format(pprint.pprint(result)))
  File "/usr/lib/python2.7/pprint.py", line 56, in pprint
    printer.pprint(object)
  File "/usr/lib/python2.7/pprint.py", line 114, in pprint
    self._format(object, self._stream, 0, 0, {}, 0)
  File "/usr/lib/python2.7/pprint.py", line 137, in _format
    rep = self._repr(object, context, level - 1)
  File "/usr/lib/python2.7/pprint.py", line 230, in _repr
    self._depth, level)
  File "/usr/lib/python2.7/pprint.py", line 242, in format
    return _safe_repr(object, context, maxlevels, level)
  File "/usr/lib/python2.7/pprint.py", line 327, in _safe_repr
    rep = repr(object)
  File "/usr/local/lib/python2.7/dist-packages/openssh_wrapper.py", line 531, in __repr__
    return self.repr_binary()
  File "/usr/local/lib/python2.7/dist-packages/openssh_wrapper.py", line 543, in repr_binary
    return b('').join(ret)
```

I don't know enough about python unicode to know if this is a proper fix,
though..
