### PR TITLE
Convert scp port to str

### DIFF
--- a/openssh_wrapper.py
+++ b/openssh_wrapper.py
@@ -369,7 +369,7 @@ class SSHConnection(object):
         if self.identity_file:
             cmd += ['-i', self.identity_file]
         if self.port:
-            cmd += ['-P', self.port]
+            cmd += ['-P', str(self.port)]
 
         if isinstance(files, (text, bytes)):
             raise ValueError('"files" argument have to be iterable (list or tuple)')

--- a/tests.py
+++ b/tests.py
@@ -71,6 +71,16 @@ class TestSCP(object):
         self.c.scp((test_file, ), target='/tmp')
         assert os.path.isfile('/tmp/tests.py')
 
+    def test_scp_int_port(self):
+        c = SSHConnection('localhost', login='root', port=22)
+        c.scp((test_file, ), target='/tmp')
+        assert os.path.isfile('/tmp/tests.py')
+
+    def test_scp_str_port(self):
+        c = SSHConnection('localhost', login='root', port='22')
+        c.scp((test_file, ), target='/tmp')
+        assert os.path.isfile('/tmp/tests.py')
+
     def test_scp_to_nonexistent_dir(self):
         with pytest.raises(SSHError):
             self.c.scp((test_file, ), target='/abc/def/')


### PR DESCRIPTION
Otherwise b_list(cmd) will raise an Exception because it can't encode the int.
Also added a test for this.
