### PR TITLE
Convert port to string for SCP command building

### DIFF
--- a/openssh_wrapper.py
+++ b/openssh_wrapper.py
@@ -369,7 +369,7 @@ class SSHConnection(object):
         if self.identity_file:
             cmd += ['-i', self.identity_file]
         if self.port:
-            cmd += ['-P', self.port]
+            cmd += ['-P', str(self.port)]
 
         if isinstance(files, (text, bytes)):
             raise ValueError('"files" argument have to be iterable (list or tuple)')


### PR DESCRIPTION
If the port is an int, scp fails due to `scp_command`'s final `b_list` trying to convert the int to a string which does not work.

This mirrors what `ssh_command` does.

e.g. with a port number (before fix)
```pythonc
>>> ret = conn.scp(("test.txt",), target="/root/test.txt")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/openssh_wrapper.py", line 219, in scp
    scp_command = self.scp_command(filenames, target)
  File "/usr/local/lib/python3.7/site-packages/openssh_wrapper.py", line 372, in scp_command
    return b_list(cmd)
  File "/usr/local/lib/python3.7/site-packages/openssh_wrapper.py", line 46, in b_list
    return [b(item) for item in items]
  File "/usr/local/lib/python3.7/site-packages/openssh_wrapper.py", line 46, in <listcomp>
    return [b(item) for item in items]
  File "/usr/local/lib/python3.7/site-packages/openssh_wrapper.py", line 30, in b
    return string.encode('utf-8')
AttributeError: 'int' object has no attribute 'encode'
```